### PR TITLE
Speak vehicle codes as numbers and add parallel alarm mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Works in any modern browser (Chrome, Edge, Firefox, Safari). Recommended: open i
 
 **Offline behavior:** the alarm core (sound, indicators, description, address) works fully offline. The map is the only online-dependent feature — it uses Leaflet + OpenStreetMap loaded from a CDN. If the CDN or tile server can't be reached, the map silently falls back to a placeholder icon; the alarm itself is unaffected. For guaranteed offline use, run the page once while online so the browser caches Leaflet.
 
-**Text-to-speech:** during an alarm, the system speaks the alarmed vehicles, Stichwort and Einsatzort in German (e.g. *"Einsatz für 1/42 und 2/42, B3 - Gebäudebrand, Mustergasse 1 Stuttgart."*). Choose under **Einstellungen → Alarmierungsart** whether to play siren only, speech only, or both alternating. Uses the browser's built-in Web Speech API. Works fully offline on macOS, Windows, and most Chrome/Edge installs. On Linux/Firefox a German voice may need to be installed separately.
+**Text-to-speech:** during an alarm, the system speaks the alarmed vehicles, Stichwort and Einsatzort in German (e.g. *"Einsatz für 1/42 und 2/42, B3 - Gebäudebrand, Mustergasse 1 Stuttgart."*). Vehicle codes containing `/` or `-` between digits (e.g. `1/42`, `1-19`) are normalized to spaces before speaking so the voice reads them as numbers, not dates. Choose under **Einstellungen → Alarmierungsart** between: siren + speech alternating, siren + speech at the same time, siren only, or speech only. Uses the browser's built-in Web Speech API. Works fully offline on macOS, Windows, and most Chrome/Edge installs. On Linux/Firefox a German voice may need to be installed separately.
 
 ## Setup
 

--- a/index.html
+++ b/index.html
@@ -521,6 +521,7 @@ function openSettings() {
         <label>Alarmierungsart</label>
         <select id="set-alarm-mode">
           <option value="both" ${s.alarmMode === "both" ? "selected" : ""}>Sirene + Sprachausgabe (abwechselnd)</option>
+          <option value="parallel" ${s.alarmMode === "parallel" ? "selected" : ""}>Sirene + Sprachausgabe (gleichzeitig)</option>
           <option value="sound" ${s.alarmMode === "sound" ? "selected" : ""}>Nur Sirene</option>
           <option value="speech" ${s.alarmMode === "speech" ? "selected" : ""}>Nur Sprachausgabe</option>
         </select>
@@ -812,11 +813,17 @@ function joinAnd(items) {
   return items.slice(0, -1).join(", ") + " und " + items[items.length - 1];
 }
 
+// Convert vehicle codes like "1/42" or "1-42" to "1 42" so German TTS
+// reads them as "eins zweiundvierzig" instead of interpreting as date.
+function speakifyLabel(label) {
+  return String(label).replace(/(\d)\s*[\/\-]\s*(\d)/g, "$1 $2");
+}
+
 function buildSpeechText(op) {
-  const on = indicators().filter(ind => op.indicators[ind.key]).map(ind => ind.label);
+  const on = indicators().filter(ind => op.indicators[ind.key]).map(ind => speakifyLabel(ind.label));
   const lead = on.length ? "Einsatz für " + joinAnd(on) : "Einsatz";
   const parts = [lead];
-  if (op.description) parts.push(op.description);
+  if (op.description) parts.push(speakifyLabel(op.description));
   if (op.address) parts.push(op.address);
   return parts.join(", ") + ".";
 }
@@ -856,9 +863,27 @@ function wait(ms) {
   });
 }
 
+function startLoopingAudio() {
+  const audio = document.getElementById("alarm-audio");
+  audio.loop = true;
+  audio.currentTime = 0;
+  audio.play().catch(e => console.warn("audio play failed", e));
+}
+
 async function runAlarmSequence(op, endTime) {
   const text = buildSpeechText(op);
   const mode = state.settings.alarmMode || "both";
+
+  if (mode === "parallel") {
+    startLoopingAudio();
+    while (runtime.alarmActive && Date.now() < endTime) {
+      if (text) await speak(text);
+      if (!runtime.alarmActive || Date.now() >= endTime) break;
+      await wait(800);
+    }
+    return;
+  }
+
   while (runtime.alarmActive && Date.now() < endTime) {
     if (mode === "sound" || mode === "both") {
       await playAudioOnce();


### PR DESCRIPTION
German TTS was interpreting labels like "1/42" or "1-42" as dates. Normalize digit-slash-digit and digit-dash-digit patterns to a space before speaking ("1 42") so the voice reads them as "eins zweiundvierzig".

Also add a fourth Alarmierungsart option, "Sirene + Sprachausgabe (gleichzeitig)", which loops the siren continuously while the spoken announcement plays on top with a short gap between repeats.